### PR TITLE
small fix to dataloader

### DIFF
--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -38,13 +38,13 @@ def get_xy(data):
         #y = data[["theta1", "theta2", "xt2"]]
         X = data[["theta1","fc1"]]
         y = data[["theta1"]]
-        
-        #y = y.shift(-1)
-        #y.iloc[-1] = y.iloc[-2]
-        #Output 
-        y = y.shift(1) - y
-        y.iloc[0] = y.iloc[1]
-        
+
+        y = y - y.shift(1) 
+
+        # discard first reading because no delta yet
+        X = X.iloc[1:]
+        y = y.iloc[1:]
+
         return X, y
     except:
         raise AttributeError("Invalid data format")


### PR DESCRIPTION
You previously had `y.shift(1) - y` and copied the second row to the first.
I changed it to `y - shift(1)` and discarded the first row for both input and output, since there's no delta then and I think it's better to throw that row away rather than invent a datapoint.

The values in each row of `y.shift(1)` are the same as the previous values of `y`. I think our delta should be the current value minus the previous one, so `y - y.shift(1)`. This will be the same as `y.shift(1) - y` but with opposite sign. Not sure if that makes any difference, but better safe than sorry? If you agree, you can pull my changes.