### PR TITLE
dataloader: align input state w/ *next* state diff

### DIFF
--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -42,12 +42,12 @@ def get_xy(data):
 
         y = y - y.shift(1) 
 
-        # discard first reading because no delta yet
-        X = X.iloc[1:]
+        X = X.iloc[:-1]
+
         y = y.iloc[1:]
 
         return X, y
-    except:
+    except Exception:
         raise AttributeError("Invalid data format")
 
 def load_training_data(train_path, normalize=True):


### PR DESCRIPTION
Revisiting this, I think that we need one more small change.

Instead of:
```
y = y - y.shift(1) 
X = X.iloc[1:]
y = y.iloc[1:]
```

we should do:
```
y = y - y.shift(1) 
X = X.iloc[:-1]
y = y.iloc[1:]
```

That way the _next_ state difference outputs will be compared with the _current_ state and control signal inputs.

Without this change, we are comparing the _current_ difference with the current state, which are not causally connected.