### PR TITLE
batched_training + cosimulation

### DIFF
--- a/GP/GpModel.py
+++ b/GP/GpModel.py
@@ -283,52 +283,55 @@ class GpModel:
         self.y_test = self.y_test.to(self.device, dtype=torch.float64)
 
         # plot for tasks
-        tasks = ["end-effector x-location",
-                 "end-effector y-location",
-                 "theta1",
-                 "theta2",
-                 "xt2",
-                 "boom_x_velocity",
-                 "boom_y_velocity",
-                 "boom_x_acceleration",
-                 "boom_y_acceleration"]
+        tasks_groups = [
+            ["end-effector x-location", "end-effector y-location"],
+            ["theta1", "theta2", "xt2"],
+            ["boom_x_velocity", "boom_y_velocity"],
+            ["boom_x_acceleration", "boom_y_acceleration"]
+        ]
 
         self.model.eval()
         self.likelihood.eval()
 
-        if plot:
-            _, axes_tasks = plt.subplots(1, len(tasks), figsize=(12, 4))
+        tasks = ["end-effector x-location",
+                "end-effector y-location",
+                "theta1",
+                "theta2",
+                "xt2",
+                "boom_x_velocity",
+                "boom_y_velocity",
+                "boom_x_acceleration",
+                "boom_y_acceleration"]
 
-        for i, task in enumerate(tasks):
+        for group in tasks_groups:
+            _, axes_tasks = plt.subplots(1, len(group), figsize=(6 * len(group), 4))
 
-            # make predictions for each task
-            with torch.no_grad(), gpytorch.settings.fast_pred_var():
-                test_x = torch.linspace(0, 1, len(self.X_test[:, 0]))
-                predictions = self.likelihood(self.model(self.X_test))
-                mean = predictions.mean
-                lower, upper = predictions.confidence_region()
-
-            if plot:
+            for i, task in enumerate(group):
+                # make predictions for each task
+                with torch.no_grad(), gpytorch.settings.fast_pred_var():
+                    test_x = torch.linspace(0, 1, len(self.X_test[:, 0]))
+                    predictions = self.likelihood(self.model(self.X_test))
+                    mean = predictions.mean
+                    lower, upper = predictions.confidence_region()
 
                 # plot training data as black stars
                 axes_tasks[i].plot(test_x.cpu().numpy(),
-                                   self.y_test[:, i].cpu().numpy(), 'k*')
+                                self.y_test[:, tasks.index(task)].cpu().numpy(), 'k*')
 
                 axes_tasks[i].plot(test_x.cpu().numpy(),
-                                   mean[:, i].cpu().numpy(), 'b')
+                                mean[:, tasks.index(task)].cpu().numpy(), 'b')
 
                 # shade in confidence
                 axes_tasks[i].fill_between(test_x.cpu().numpy(),
-                                           lower[:, i].cpu().numpy(),
-                                           upper[:, i].cpu().numpy(),
-                                           alpha=0.5)
+                                        lower[:, tasks.index(task)].cpu().numpy(),
+                                        upper[:, tasks.index(task)].cpu().numpy(),
+                                        alpha=0.5)
 
                 axes_tasks[i].set_ylim([-0.2, 1.3])
                 axes_tasks[i].legend(["Observed Data", "Mean", "Confidence"])
-                axes_tasks[i].set_title("Observed Values (Likelihood), "
-                                        f"{task}")
+                axes_tasks[i].set_title(f"Observed Values (Likelihood), {task}")
 
-        plt.show()
+            plt.show()
 
     def predict(self, X):
         """

--- a/RL/Policy.py
+++ b/RL/Policy.py
@@ -647,7 +647,7 @@ class RlPolicy:
                             start_state:     dict,
                             target_location: dict,
                             iterations:      int            = 100,
-                            online_learning: bool           = True
+                            online_learning: bool           = True,
                             callback:        Callable[dict] = None):
 
         """
@@ -701,6 +701,9 @@ class RlPolicy:
                         ).item()
 
         state = start_state
+
+        if callback is not None:
+            callback(state = deepcopy(state))
 
         display_state(state)
 
@@ -763,7 +766,7 @@ class RlPolicy:
 
     def simulate_random_trajectory(self,
                                    iterations:      int            = 100,
-                                   online_learning: bool           = True
+                                   online_learning: bool           = True,
                                    callback:        Callable[dict] = None):
 
         """

--- a/RL/Policy.py
+++ b/RL/Policy.py
@@ -8,7 +8,7 @@ from os import listdir, mkdir
 from os.path import dirname, isdir, join
 from pathlib import Path
 from random import randint, random
-from typing import Literal
+from typing import Callable, Literal
 
 import torch
 from tqdm import tqdm
@@ -460,6 +460,8 @@ class RlPolicy:
 
                 progress_bar.update()
 
+        print()
+
     def select_actions(self, network, states, ε = 0, quiet = False):
         """
         given a batch of states, output a batch of actions
@@ -642,15 +644,21 @@ class RlPolicy:
             states = next_states
 
     def simulate_trajectory(self,
-                            start_state,
-                            target_location,
-                            iterations      = 100,
-                            online_learning = True):
+                            start_state:     dict,
+                            target_location: dict,
+                            iterations:      int            = 100,
+                            online_learning: bool           = True
+                            callback:        Callable[dict] = None):
 
         """
         simulate the trajectory from a given start state to a given target
         location, using the trained RL & GP models, optionally continuing
         training online
+
+        A callback function can optionally be passed as an argument. The
+        callback function should accept a single argument `state`, of type
+        dict. Each time the state is updated  with a new prediction from the
+        GP, it will be passed to the callback function.
         """
 
         def display_state(state):
@@ -730,6 +738,9 @@ class RlPolicy:
             print("percent distance covered: "
                   f"{(initial_distance - distance) / initial_distance:.1%}")
 
+            if callback is not None:
+                callback(state = deepcopy(next_state))
+
             if online_learning:
 
                 reward = self.calculate_rewards(next_state)
@@ -751,12 +762,17 @@ class RlPolicy:
             # TODO stop when "close enough" to goal
 
     def simulate_random_trajectory(self,
-                                   iterations      = 100,
-                                   online_learning = True):
+                                   iterations:      int            = 100,
+                                   online_learning: bool           = True
+                                   callback:        Callable[dict] = None):
 
         """
         randomly sample a start state and target location from ground-truth
         data, then simulate the trajectory using the RL & GP models
+
+        A callback function can optionally be passed as an argument. All
+        arguments be passed to the more general `simulate_random_trajectory()`
+        method above, so see its docstring for details.
         """
 
         if online_learning:

--- a/RL/Policy.py
+++ b/RL/Policy.py
@@ -643,12 +643,13 @@ class RlPolicy:
 
             states = next_states
 
-    def simulate_trajectory(self,
-                            start_state:     dict,
-                            target_location: dict,
-                            iterations:      int            = 100,
-                            online_learning: bool           = True,
-                            callback:        Callable[dict] = None):
+    def simulate_trajectory(
+        self,
+        start_state:     dict,
+        target_location: dict,
+        iterations:      int                          = 100,
+        online_learning: bool                         = True,
+        callback:        Callable[[dict, None], None] = None):
 
         """
         simulate the trajectory from a given start state to a given target
@@ -764,10 +765,11 @@ class RlPolicy:
 
             # TODO stop when "close enough" to goal
 
-    def simulate_random_trajectory(self,
-                                   iterations:      int            = 100,
-                                   online_learning: bool           = True,
-                                   callback:        Callable[dict] = None):
+    def simulate_random_trajectory(
+        self,
+        iterations:      int                          = 100,
+        online_learning: bool                         = True,
+        callback:        Callable[[dict, None], None] = None):
 
         """
         randomly sample a start state and target location from ground-truth

--- a/RL/Policy.py
+++ b/RL/Policy.py
@@ -156,7 +156,8 @@ class PolicyNetwork:
         end_model_training = time.perf_counter()
         elapsed_model_training = end_model_training - start_model_training
         print("training time: ", elapsed_model_training)
-        self.write_RL_results()
+        if False:
+            self.write_RL_results()
 
     def calculate_step_reward(self):
         """calculate and return reward for a single time step"""
@@ -364,7 +365,7 @@ class PolicyNetwork:
         print(RL_results_np)
 
         # Define the CSV file path
-        csv_file_path = '/home/titta/Documents/rpw/RL_Project/stash/RL_results.csv'
+        csv_file_path = '/RL_results.csv'
 
         # Open the CSV file for writing
         with open(csv_file_path, 'w', newline='') as csvfile:
@@ -391,13 +392,12 @@ class PolicyNetwork:
                 joint_tensor = joint_tensor.view(1, -1)
                 joint_tensor = self.scalers["joints"].inverse_transform(joint_tensor)
                 joint_tensor = joint_tensor[0]
-                print(joint_tensor[0])
+                
 
                 torque_tensor = torch.from_numpy(np.array([torque1, torque2, torque3]))
                 torque_tensor = torque_tensor.view(1, -1)
                 torque_tensor = self.scalers["torques"].inverse_transform(torque_tensor)
                 torque_tensor = torque_tensor[0]
-                print(torque_tensor[0])
 
 
                 csv_writer.writerow([time, ee[0], ee[1], joint_tensor[0], joint_tensor[1], joint_tensor[2], torque_tensor[0], torque_tensor[1], torque_tensor[2]])

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,9 +1,12 @@
 data_path: "trajectories/10Hz/all_joints"
 GP:
-  model_path: "trained_models/all_joints.pth"
+  model_path: "/home/titta/Documents/rpw/RL_Project/saved_models/all_joints_500iter.pth"
   iterations: 116
 RL:
   train_fresh_GP: false
-  trials: 10
-  iterations: 1000
+  trials: 1
+  iterations: 100
   learning_rate: 0.1
+  
+  
+  

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,9 +1,8 @@
 data_path: "trajectories/10Hz/all_joints"
 GP:
-  model_path: "trained_models/all_joints.pth"
+  model_path: "/home/titta/Documents/rpw/RL_Project/saved_models/all_joints_500iter.pth"
   iterations: 116
 RL:
   train_fresh_GP: false
-  trials: 10
-  iterations: 1000
-  learning_rate: 0.1
+  iterations: 100
+  learning_rate: 0.01

--- a/cosimulation.py
+++ b/cosimulation.py
@@ -1,0 +1,70 @@
+"""MATLAB/Simulink cosimulation"""
+
+import socket
+import struct
+import yaml
+
+import matlab.engine
+
+from GP.GpModel import GpModel
+from RL.Policy import RlPolicy
+
+HOST = '127.0.0.1'
+PORT = 12345
+
+
+def callback(self, state: dict):
+    """
+    accepts a state from `RlPolicy.simulate_random_trajectory()` and sends
+    its joint configuration to the MATLAB Simulink model via TCP/IP socket
+    """
+
+    joint_array = state["joints"].cpu().detach().numpy()
+
+    joint_array = joint_array.flatten()
+
+    joint_tensor = (self.scalers["joints"]
+                    .inverse_transform(joint_array.reshape(1, -1)))
+
+    joint_tensor = joint_tensor[0]
+
+    joint1, joint2, joint3 = joint_tensor[:3]
+
+    print("joints:", joint1, joint2, joint3)
+
+    try:
+
+        data = struct.pack('!ddd', joint1, joint2, joint3)
+
+        matlab_socket.sendall(data)
+
+        print("Joints sent successfully.")
+
+    except Exception as exception:
+        print(f"Error connecting to MATLAB: {exception}")
+
+
+with open("configuration.yaml") as configuration_file:
+
+    configuration = yaml.load(configuration_file,
+                              Loader = yaml.SafeLoader)
+
+matlab.engine.start_matlab()
+
+matlab_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+matlab_socket.connect((HOST, PORT))
+
+gp_model = GpModel(data_path        = configuration["data_path"],
+                   saved_model_path = configuration["GP"]["model_path"])
+
+rl_policy = RlPolicy(gp_model         = gp_model,
+                     data_path        = configuration["data_path"],
+                     saved_model_path = configuration["RL"]["model_path"])
+
+rl_policy.simulate_random_trajectory(
+    iterations      = configuration["RL"]["iterations"],
+    online_learning = True,
+    callback        = callback)
+
+matlab_socket.close()

--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -148,7 +148,8 @@ def load_data_directory(path):
     for csv_file in csv_files:
         file_path = os.path.join(path, csv_file)
         df = pd.read_csv(file_path)
-        combined_df.append(df)
+        if(iteration%3 == 0):
+            combined_df.append(df)
         iteration += 1
 
     combined_df = pd.concat(combined_df, ignore_index=True)
@@ -292,17 +293,19 @@ def plot_X_train_vs_time(X, names):
 
 if __name__ == "__main__":
     # training_path = "data/some_chill_trajectories/trajectory12_10Hz.csv"
-    # data_path = "data/some_chill_trajectories/trajectory17_10Hz.csv"
-    training_path = "data/two-joint_trajectories_10Hz/trajectory2.csv"
-    testing_path = "data/two-joint_trajectories_10Hz/trajectory3.csv"
+    # data_path = "data/some_chill_trajectories/trajectory17_10Hz.csv"False
+    training_path = "trajectories/10Hz/all_joints/trajectory80.csv"
+    #testing_path = "data/two-joint_trajectories_10Hz/trajectory3.csv"
 
     data_directory = 'data/two-joint_trajectories_10Hz'
 
     X_train, y_train = load_training_data(training_path, True)
-    X_test, y_test = load_testing_data(testing_path, True)
+    #plot_X_train_vs_time(X_train, X_names)
+
+    #X_test, y_test = load_testing_data(testing_path, True)
 
     X_train, X_test, y_train, y_test = load_data_directory(data_directory)
-    print(X_train.shape, X_test.shape)
+    #print(X_train.shape, X_test.shape)
 
     plot_X_train_vs_time(X_train, X_names)
     plot_X_train_vs_time(X_test, X_names)

--- a/train_RL.py
+++ b/train_RL.py
@@ -23,7 +23,7 @@ def main(configuration):
             GpModel(data_path        = configuration["data_path"],
                     saved_model_path = configuration["GP"]["model_path"])
 
-    gp_model.test(plot=True)
+    #gp_model.test(plot=True)
 
     rl_policy = RlPolicy(gp_model  = gp_model,
                          data_path = configuration["data_path"])

--- a/train_RL.py
+++ b/train_RL.py
@@ -23,7 +23,7 @@ def main(configuration):
             GpModel(data_path        = configuration["data_path"],
                     saved_model_path = configuration["GP"]["model_path"])
 
-    gp_model.test(plot=True)
+    #gp_model.test(plot=True)
 
     policy_network = \
         PolicyNetwork(gp_model      = gp_model,


### PR DESCRIPTION
This PR is simply to merge the MATLAB/Simulink cosimulation feature from the `cosimulation` branch into the `batched_training` branch.

As stated in Telegram, I do not think that the `RlPolicy` class should be tightly coupled with MATLAB cosimulation. This would prevent someone not running or not wishing to run MATLAB from being able to train the RL model independently.

As a solution, I introduced a callback function in `RlPolicy.simulate_random_trajectory()` and `RlPolicy.simulate_trajectory()`. Each time the state is updated in the RL/GP simulation loop, the state is passed to the callback function.

I then moved the cosimulation-related code into its own module: `cosimulation.py`. This module should initialize the MATLAB socket connection, instantiate GP and RL models using weights specified in the configuration YAML file, and pass its own callback function to `RlPolicy.simulate_random_trajectory()`.

Since I am only able to run GPU-based code in a non-graphical environment where I obviously can't run MATLAB, I ask that you please test this.